### PR TITLE
[fix] Fix table not found uncatchable errors, extract method to make indexes easier to deal with.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
   include:
     - node_js: '12'
     - node_js: '10'
-    - node_js: '8'
 # https://github.com/greenkeeperio/greenkeeper-lockfile#npm
 before_install:
 # package-lock.json was introduced in npm@5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-- Make sure we can catch exceptions from `findAll`
+- [#3] Make sure we can catch exceptions from `findAll`
 - Make sure callers can easily call a `findAll` variant with indexes
 
 ### 1.1.1
@@ -17,3 +17,4 @@
 
 [#1]: https://github.com/godaddy/dynastar/pull/1
 [#2]: https://github.com/godaddy/dynastar/pull/2
+[#3]: https://github.com/godaddy/dynastar/pull/3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [#3] Make sure we can catch exceptions from `findAll`
 - Make sure callers can easily call a `findAll` variant with indexes
+- Dropped `node@8` support
 
 ### 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+- Make sure we can catch exceptions from `findAll`
+- Make sure callers can easily call a `findAll` variant with indexes
+
 ### 1.1.1
 
 - [#2] Remove Global Table attributes (`aws:rep:deleting`, `aws:rep:updatetime`, `aws:rep:updateregion`) when creating or updating records.

--- a/await-wrap.js
+++ b/await-wrap.js
@@ -19,6 +19,7 @@ class AwaitWrap {
     this.model = model;
     this._hoist(model);
   }
+
   /**
    * Hoist any labeled hoistable functions found on the Dynastar compatibility wrapper
    *
@@ -39,8 +40,8 @@ class AwaitWrap {
         }
       }
     }
-
   }
+
   /**
    * Thenable wrap the create method
    *
@@ -80,6 +81,7 @@ class AwaitWrap {
   findOne() {
     return thenify(this.model, 'findOne', ...arguments);
   }
+
   /**
    * Thenable wrap the get method
    *
@@ -89,6 +91,7 @@ class AwaitWrap {
   get() {
     return this.findOne(...arguments);
   }
+
   /**
    * Return the normal model findAll for the stream
    * @function findAllStream
@@ -110,6 +113,16 @@ class AwaitWrap {
   }
 
   /**
+   * Thenable wrap the loadAllQuery method
+   *
+   * @function findAll
+   * @returns {Thenable} wrapped result
+   */
+  findAllQuery() {
+    return thenify(this.model, 'findAllQuery', ...arguments);
+  }
+
+  /**
    * Thenable wrap the ensureTables method
    *
    * @function ensure
@@ -118,6 +131,7 @@ class AwaitWrap {
   ensure() {
     return this.ensureTables();
   }
+
   /**
    * Thenable wrap the ensureTables method
    *
@@ -137,6 +151,7 @@ class AwaitWrap {
   drop() {
     return this.dropTables();
   }
+
   /**
    * Thenable wrap the dropTables method
    *

--- a/index.js
+++ b/index.js
@@ -135,9 +135,14 @@ class Dynastar {
       cb();
     }));
 
+    // Proxy errors to the output stream
+    rawStream.on('error', function (error) {
+      stream.emit('error', error);
+    });
+
     if (callback) {
       const lsStream = stream.pipe(ls.obj(callback));
-      rawStream.on('error', callback);
+      // Proxy errors to the callback
       stream.on('error', callback);
       lsStream.on('error', callback);
       return lsStream;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const through = require('through2');
 const ls = require('list-stream');
+const once = require('once');
 const AwaitWrap = require('./await-wrap');
 
 /**
@@ -20,13 +21,14 @@ class Dynastar {
     this.hashKey = hashKey;
     this.rangeKey = rangeKey;
     this._createKey = createKey;
+
     // The idea of what we are doing here is to enable a way for functions to be
     // added to this class while also being able to track their name so other wrappers
     // like AwaitWrap can auto hoist them as well
     this.hoistable = Object.keys(fns);
     Object.assign(this, fns);
-
   }
+
   /**
    * @function create
    * @param {Object} data Model data object
@@ -37,6 +39,7 @@ class Dynastar {
     const opts = this._computeKeyOpts(data);
     return this.model.create(this._omitGlobalTableData({ ...opts, ...data }), callback);
   }
+
   /**
    * @function update
    * @param {Object} data Model data object
@@ -47,6 +50,7 @@ class Dynastar {
     const opts = this._computeKeyOpts(data);
     return this.model.update(this._omitGlobalTableData({ ...opts, ...data }), callback);
   }
+
   /**
    * @function remove
    * @param {Object} data Model data object
@@ -57,6 +61,7 @@ class Dynastar {
     const opts = this._computeKeyOpts(data);
     return this.model.destroy(opts, callback);
   }
+
   /**
    * @function get
    * @param {Object} data Model data object
@@ -69,6 +74,7 @@ class Dynastar {
       callback(err, res && res.toJSON());
     });
   }
+
   /**
    * @function findOne
    * @param {Object} data Model data object
@@ -77,6 +83,7 @@ class Dynastar {
   findOne() {
     return this.get(...arguments);
   }
+
   /**
    * @function findAll
    * @param {Object} data Datastar find object or model data object
@@ -98,20 +105,47 @@ class Dynastar {
 
     const query = key ? this.model.query(key) : this.model.scan();
     if (fields) query.attributes(fields);
-    // These models are weird and dont even have proper getters so we have to
+
+    return this.findAllQuery(query, callback);
+  }
+
+  /**
+   * Safely runs a query (or table scan).
+   * This is useful when you need to query a secondary indexes and want our default item parsing logic.
+   *
+   * @function findAllQuery
+   * @param {Object} query A DynamoDB model query or scan object to execute
+   * @param {Function} [callback] Continuation function when finished
+   * @returns {Stream} Stream with results
+   */
+  findAllQuery(query, callback) {
+    if (callback) {
+      callback = once(callback);
+    }
+
+    // These models are weird and don't even have proper getters so we have to
     // just use it as raw json so we can expect the object to have
     // properties
-    const stream = query.loadAll().exec().pipe(through.obj(function (res, enc, cb) {
+    const rawStream = query.loadAll().exec();
+    const stream = rawStream.pipe(through.obj(function (res, enc, cb) {
       res = res.Items || res;
       for (const d of res) {
         this.push(d && d.toJSON());
       }
       cb();
     }));
-    if (callback) return stream.pipe(ls.obj(callback));
-    return stream;
 
+    if (callback) {
+      const lsStream = stream.pipe(ls.obj(callback));
+      rawStream.on('error', callback);
+      stream.on('error', callback);
+      lsStream.on('error', callback);
+      return lsStream;
+    }
+
+    return stream;
   }
+
   /**
    *  @function ensureTables
    *  @returns {any} whatever the model returns
@@ -119,6 +153,7 @@ class Dynastar {
   ensureTables() {
     return this.model.createTable(...arguments);
   }
+
   /**
    * @function dropTables
    * @returns {any} whatever the model returns
@@ -126,6 +161,7 @@ class Dynastar {
   dropTables() {
     return this.model.deleteTable(...arguments);
   }
+
   /**
    * @function _computeKeyOpts
    * @param {Object} data Parameters for given model

--- a/package-lock.json
+++ b/package-lock.json
@@ -1944,7 +1944,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -2927,8 +2926,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "list-stream": "^2.0.0",
+    "once": "^1.4.0",
     "through2": "^3.0.1",
     "tinythen": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.1",
   "description": "A simple compatibility layer for dynamodb models to be compatible with the datastar model API",
   "main": "index.js",
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "dependencies": {
     "list-stream": "^2.0.0",
     "once": "^1.4.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,8 +38,22 @@ describe('Dynastar - index.js', function () {
       hello: Joi.string(),
       what: dynamo.types.timeUUID(),
       another: Joi.string().allow(null)
-    }
+    },
+    indexes: [{
+      name: 'ByIndex',
+      hashKey: 'another',
+      type: 'global'
+    }]
   });
+
+  function findByIndex(data, callback) {
+    const { another, hello } = data;
+
+    let query = this.model.query(another).usingIndex('ByIndex');
+    if (hello) query = query.where('hello').equals(hello);
+
+    this.findAllQuery(query, callback);
+  }
 
   before(function (done) {
     wrapped = new Dynastar({ model, hashKey, rangeKey });
@@ -63,6 +77,30 @@ describe('Dynastar - index.js', function () {
 
   after(function (done) {
     wrapped.dropTables(done);
+  });
+
+  it('should catch table not found errors', function (done) {
+    const myHashKey = 'hello';
+    const myModel = dynamo.define('badTable', {
+      hashKey,
+      rangeKey,
+      schema: {
+        hello: Joi.string(),
+        world: Joi.string().allow(null)
+      }
+    });
+
+    const myWrapped = new Dynastar({
+      model: myModel,
+      hashKey: myHashKey
+    });
+
+    myWrapped.findAll({
+      hello: 'world'
+    }, (error) => {
+      assume(error).is.truthy();
+      done();
+    });
   });
 
   it('should support the datastar api interface', function () {
@@ -224,6 +262,29 @@ describe('Dynastar - index.js', function () {
         const modified = await wmodel.somethingAsync(res);
         assume(modified.somethingAsync).is.true();
       }
+    });
+
+    it('should allow query by index', function (done) {
+      const wmodel = new Dynastar({ model, hashKey, rangeKey, findByIndex });
+      assume(wmodel.findByIndex).is.a('function');
+
+      wmodel.create({ hello: 'bob', another: 'foo' }, (error) => {
+        if (error) return done(error);
+
+        wmodel.create({ hello: 'cruel world', another: 'foo' }, (error2) => {
+          if (error2) return done(error2);
+
+          wmodel.findByIndex({ another: 'foo' }, (findError, results) => {
+            if (findError) return done(findError);
+
+            assume(results).to.have.length(2);
+            const hellos = results.map(r => r.hello);
+            assume(hellos).contains('bob');
+            assume(hellos).contains('cruel world');
+            done();
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
I hit this in my dev environment. I had a site running connected to a localstack dynamodb, everything was working. Meanwhile I ran my unit tests, which dropped the tables.  Running `findAll` yielded an uncatchable exception that crashed my site. The root cause was errors from the streams weren't being passed through.

I've also extracted the streams portion of `findAll` to make it easier to build index-based queries. An example is in the unit tests here.

