### PR TITLE
[feat] Allow for options data to pass through to dynamodb to allow fo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- [#4] Allow for additional options to get passed in where not already available (`get`, `create`, `update`, `remove`).
+
 ### 1.1.1
 
 - [#2] Remove Global Table attributes (`aws:rep:deleting`, `aws:rep:updatetime`, `aws:rep:updateregion`) when creating or updating records.
@@ -14,3 +16,4 @@
 
 [#1]: https://github.com/godaddy/dynastar/pull/1
 [#2]: https://github.com/godaddy/dynastar/pull/2
+[#4]: https://github.com/godaddy/dynastar/pull/4

--- a/index.js
+++ b/index.js
@@ -30,42 +30,51 @@ class Dynastar {
   /**
    * @function create
    * @param {Object} data Model data object
+   * @param {Object} [options] Optional options object
    * @param {Function} callback Continuation function when finished
    * @returns {any} whatever the model returns
    */
-  create(data, callback) {
+  create(data, ...args) {
     const opts = this._computeKeyOpts(data);
-    return this.model.create(this._omitGlobalTableData({ ...opts, ...data }), callback);
+    return this.model.create(this._omitGlobalTableData({ ...opts, ...data }), ...args);
   }
   /**
    * @function update
    * @param {Object} data Model data object
+   * @param {Object} [options] Optional options object
    * @param {Function} callback Continuation function when finished
    * @returns {any} whatever the model returns
    */
-  update(data, callback) {
+  update(data, ...args) {
     const opts = this._computeKeyOpts(data);
-    return this.model.update(this._omitGlobalTableData({ ...opts, ...data }), callback);
+    return this.model.update(this._omitGlobalTableData({ ...opts, ...data }), ...args);
   }
   /**
    * @function remove
    * @param {Object} data Model data object
+   * @param {Object} [options] Optional options object
    * @param {Function} callback Continuation function when finished
    * @returns {any} whatever the model returns
    */
-  remove(data, callback) {
+  remove(data, ...args) {
     const opts = this._computeKeyOpts(data);
-    return this.model.destroy(opts, callback);
+    return this.model.destroy(opts, ...args);
   }
   /**
    * @function get
    * @param {Object} data Model data object
+   * @param {Object} [options] Optional options object
    * @param {Function} callback Continuation function when finished
    * @returns {any} whatever the model returns
    */
-  get(data, callback) {
+  get(data, options, callback) {
+    if (!callback && typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
     const opts = this._computeKeyOpts(data);
-    return this.model.get(opts, (err, res) => {
+    return this.model.get(opts, options, (err, res) => {
       callback(err, res && res.toJSON());
     });
   }


### PR DESCRIPTION
…r non-overwriting writes, conditional updates and deletes, etc.

Hit this when trying to do `myModel.create(spec, { overwrite: false}, callback)` and my callback was eaten by dynastar.  Seems useful enough to pass the remainder through where we weren't already doing so so added those as well along with the appropriate tests.